### PR TITLE
Fix observer name parameter to work for Catalina

### DIFF
--- a/NSDistributedNotificationCenter Example/AppDelegate.m
+++ b/NSDistributedNotificationCenter Example/AppDelegate.m
@@ -38,7 +38,7 @@
     [[NSDistributedNotificationCenter defaultCenter]
      addObserver:self
      selector:@selector(distributedNotificationHandler:)
-     name:nil // e.g. AppleSelectedInputSourcesChangedNotification
+     name:[[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleIdentifierKey] // e.g. AppleSelectedInputSourcesChangedNotification
      object:nil];
 }
 


### PR DESCRIPTION
In macOS Catalina, listening to NSDistributedNotifications with `nil` name was made a privileged operation. This fixes the example so that it works on Catalina.